### PR TITLE
Stub implementation

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,7 +87,10 @@ func run(conf *config.Config) error {
 	go func() {
 		sig := <-sigs
 		log.Info().Str("signal", fmt.Sprint(sig)).Msg("Signal received!")
-		server.Server.Unmount()
+		err := server.Server.Unmount()
+		if err != nil {
+			log.Err(err).Msg("unsuccessful unmount")
+		}
 	}()
 
 	server.Wait()

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/rs/zerolog/log"
 )
 
 type rfsRoot struct {
@@ -27,6 +28,8 @@ func (n *rfsRoot) Create(ctx context.Context, name string, flags uint32, mode ui
 
 	fakeError := syscall.EEXIST
 
+	log.Info().Msg("error for create: EEXIST: File exists")
+
 	return inode, fh, fflags, fakeError
 }
 
@@ -34,6 +37,11 @@ func (n *rfsRoot) Link(ctx context.Context, target fs.InodeEmbedder, name string
 	inode, _ := n.LoopbackNode.Link(ctx, target, name, out)
 
 	fakeError := syscall.EXDEV
+
+	// TODO: something is wrong with this func
+	// When try to ln -s then error is: EMFILE Too many open files in system
+	// When try to ln then error is: Invalid cross-device link
+	log.Info().Msg("error for link: EXDEV: ")
 
 	return inode, fakeError
 }
@@ -43,6 +51,8 @@ func (n *rfsRoot) Mkdir(ctx context.Context, name string, mode uint32, out *fuse
 	inode, _ := n.LoopbackNode.Mkdir(ctx, name, mode, out)
 
 	fakeError := syscall.EAGAIN
+
+	log.Info().Msg("error for mkdir: EAGAIN: Resource temporarily unavailable")
 
 	return inode, fakeError
 }

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -64,6 +64,14 @@ func (n *rfsRoot) Rmdir(ctx context.Context, name string) syscall.Errno {
 	return fakeError
 }
 
+func (n *rfsRoot) Setattr(ctx context.Context, fh fs.FileHandle, in *fuse.SetAttrIn, out *fuse.AttrOut) syscall.Errno {
+	_ = n.LoopbackNode.Setattr(ctx, fh, in, out)
+
+	fakeError := syscall.ENOSYS
+
+	return fakeError
+}
+
 func (n *rfsRoot) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
 	fh, flags, _ := n.LoopbackNode.Open(ctx, flags)
 

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -33,15 +33,13 @@ func (n *rfsRoot) Create(ctx context.Context, name string, flags uint32, mode ui
 	return inode, fh, fflags, fakeError
 }
 
+// Link is for hard link, not for symlink
 func (n *rfsRoot) Link(ctx context.Context, target fs.InodeEmbedder, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
 	inode, _ := n.LoopbackNode.Link(ctx, target, name, out)
 
 	fakeError := syscall.EXDEV
 
-	// TODO: something is wrong with this func
-	// When try to ln -s then error is: EMFILE Too many open files in system
-	// When try to ln then error is: Invalid cross-device link
-	log.Info().Msg("error for link: EXDEV: ")
+	log.Info().Msg("error for link: EXDEV: Cross-device link")
 
 	return inode, fakeError
 }
@@ -52,7 +50,7 @@ func (n *rfsRoot) Mkdir(ctx context.Context, name string, mode uint32, out *fuse
 
 	fakeError := syscall.EAGAIN
 
-	log.Info().Msg("error for mkdir: EAGAIN: Resource temporarily unavailable")
+	log.Info().Msg("error for mkdir: EAGAIN: Resource temporarily unavailable / Try again")
 
 	return inode, fakeError
 }
@@ -63,6 +61,8 @@ func (n *rfsRoot) Rename(ctx context.Context, name string, newParent fs.InodeEmb
 
 	fakeError := syscall.EBADF
 
+	log.Info().Msg("error for rename: EBADF: File descriptor in bad state")
+
 	return fakeError
 }
 
@@ -70,6 +70,8 @@ func (n *rfsRoot) Rmdir(ctx context.Context, name string) syscall.Errno {
 	_ = n.LoopbackNode.Rmdir(ctx, name)
 
 	fakeError := syscall.EISDIR
+
+	log.Info().Msg("error for rmdir: EISDIR: Is a directory")
 
 	return fakeError
 }
@@ -79,6 +81,8 @@ func (n *rfsRoot) Setattr(ctx context.Context, fh fs.FileHandle, in *fuse.SetAtt
 
 	fakeError := syscall.ENOSYS
 
+	log.Info().Msg("error for setattr: ENOSYS: Function not implemented")
+
 	return fakeError
 }
 
@@ -87,6 +91,8 @@ func (n *rfsRoot) Symlink(ctx context.Context, target, name string, out *fuse.En
 
 	fakeError := syscall.ENFILE
 
+	log.Info().Msg("error for symlink: ENFILE: Too many open files in system")
+
 	return inode, fakeError
 }
 
@@ -94,6 +100,8 @@ func (n *rfsRoot) Unlink(ctx context.Context, name string) syscall.Errno {
 	_ = n.LoopbackNode.Unlink(ctx, name)
 
 	fakeError := syscall.ENOSPC
+
+	log.Info().Msg("error for unlink: ENOSPC: No space left on device")
 
 	return fakeError
 }
@@ -104,6 +112,8 @@ func (n *rfsRoot) CopyFileRange(ctx context.Context, fhIn fs.FileHandle,
 	fflags, _ := n.LoopbackNode.CopyFileRange(ctx, fhIn, offIn, out, fhOut, offOut, len, flags)
 
 	fakeError := syscall.ETXTBSY
+
+	log.Info().Msg("error for copyfilerange: ETXTBSY: ")
 
 	return fflags, fakeError
 }

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -56,6 +56,14 @@ func (n *rfsRoot) Rename(ctx context.Context, name string, newParent fs.InodeEmb
 	return fakeError
 }
 
+func (n *rfsRoot) Rmdir(ctx context.Context, name string) syscall.Errno {
+	_ = n.LoopbackNode.Rmdir(ctx, name)
+
+	fakeError := syscall.EISDIR
+
+	return fakeError
+}
+
 func (n *rfsRoot) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
 	fh, flags, _ := n.LoopbackNode.Open(ctx, flags)
 

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -38,6 +38,15 @@ func (n *rfsRoot) Link(ctx context.Context, target fs.InodeEmbedder, name string
 	return inode, fakeError
 }
 
+func (n *rfsRoot) Mkdir(ctx context.Context, name string, mode uint32, out *fuse.EntryOut) (*fs.Inode,
+	syscall.Errno) {
+	inode, _ := n.LoopbackNode.Mkdir(ctx, name, mode, out)
+
+	fakeError := syscall.EAGAIN
+
+	return inode, fakeError
+}
+
 func (n *rfsRoot) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
 	fh, flags, _ := n.LoopbackNode.Open(ctx, flags)
 

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -80,6 +80,14 @@ func (n *rfsRoot) Symlink(ctx context.Context, target, name string, out *fuse.En
 	return inode, fakeError
 }
 
+func (n *rfsRoot) Unlink(ctx context.Context, name string) syscall.Errno {
+	_ = n.LoopbackNode.Unlink(ctx, name)
+
+	fakeError := syscall.ENOSPC
+
+	return fakeError
+}
+
 func (n *rfsRoot) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
 	fh, flags, _ := n.LoopbackNode.Open(ctx, flags)
 

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -72,6 +72,14 @@ func (n *rfsRoot) Setattr(ctx context.Context, fh fs.FileHandle, in *fuse.SetAtt
 	return fakeError
 }
 
+func (n *rfsRoot) Symlink(ctx context.Context, target, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+	inode, _ := n.LoopbackNode.Symlink(ctx, target, name, out)
+
+	fakeError := syscall.ENFILE
+
+	return inode, fakeError
+}
+
 func (n *rfsRoot) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
 	fh, flags, _ := n.LoopbackNode.Open(ctx, flags)
 

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -55,6 +55,16 @@ func (n *rfsRoot) Mkdir(ctx context.Context, name string, mode uint32, out *fuse
 	return inode, fakeError
 }
 
+func (n *rfsRoot) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
+	fh, fflags, _ := n.LoopbackNode.Open(ctx, flags)
+
+	fakeError := syscall.ENOTTY
+
+	log.Info().Msg("error message for open: ENOTTY: Not a typewriter")
+
+	return fh, fflags, fakeError
+}
+
 func (n *rfsRoot) Rename(ctx context.Context, name string, newParent fs.InodeEmbedder, newName string,
 	flags uint32) syscall.Errno {
 	_ = n.LoopbackNode.Rename(ctx, name, newParent, newName, flags)

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -97,11 +97,3 @@ func (n *rfsRoot) CopyFileRange(ctx context.Context, fhIn fs.FileHandle,
 
 	return fflags, fakeError
 }
-
-func (n *rfsRoot) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
-	fh, flags, _ := n.LoopbackNode.Open(ctx, flags)
-
-	fakeError := syscall.EBUSY
-
-	return fh, flags, fakeError
-}

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -5,6 +5,7 @@ import (
 	"syscall"
 
 	"github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
 )
 
 type rfsRoot struct {
@@ -18,6 +19,15 @@ func newRfsRoot(r *fs.LoopbackRoot, p *fs.Inode, n string, st *syscall.Stat_t) f
 		},
 	}
 	return node
+}
+
+func (n *rfsRoot) Create(ctx context.Context, name string, flags uint32, mode uint32,
+	out *fuse.EntryOut) (*fs.Inode, fs.FileHandle, uint32, syscall.Errno) {
+	inode, fh, fflags, _ := n.LoopbackNode.Create(ctx, name, flags, mode, out)
+
+	fakeError := syscall.EEXIST
+
+	return inode, fh, fflags, fakeError
 }
 
 func (n *rfsRoot) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -52,7 +52,7 @@ func (n *rfsRoot) Rename(ctx context.Context, name string, newParent fs.InodeEmb
 	_ = n.LoopbackNode.Rename(ctx, name, newParent, newName, flags)
 
 	fakeError := syscall.EBADF
-	
+
 	return fakeError
 }
 

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -47,6 +47,15 @@ func (n *rfsRoot) Mkdir(ctx context.Context, name string, mode uint32, out *fuse
 	return inode, fakeError
 }
 
+func (n *rfsRoot) Rename(ctx context.Context, name string, newParent fs.InodeEmbedder, newName string,
+	flags uint32) syscall.Errno {
+	_ = n.LoopbackNode.Rename(ctx, name, newParent, newName, flags)
+
+	fakeError := syscall.EBADF
+	
+	return fakeError
+}
+
 func (n *rfsRoot) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
 	fh, flags, _ := n.LoopbackNode.Open(ctx, flags)
 

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -88,6 +88,16 @@ func (n *rfsRoot) Unlink(ctx context.Context, name string) syscall.Errno {
 	return fakeError
 }
 
+func (n *rfsRoot) CopyFileRange(ctx context.Context, fhIn fs.FileHandle,
+	offIn uint64, out *fs.Inode, fhOut fs.FileHandle, offOut uint64,
+	len uint64, flags uint64) (uint32, syscall.Errno) {
+	fflags, _ := n.LoopbackNode.CopyFileRange(ctx, fhIn, offIn, out, fhOut, offOut, len, flags)
+
+	fakeError := syscall.ETXTBSY
+
+	return fflags, fakeError
+}
+
 func (n *rfsRoot) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
 	fh, flags, _ := n.LoopbackNode.Open(ctx, flags)
 

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -30,6 +30,14 @@ func (n *rfsRoot) Create(ctx context.Context, name string, flags uint32, mode ui
 	return inode, fh, fflags, fakeError
 }
 
+func (n *rfsRoot) Link(ctx context.Context, target fs.InodeEmbedder, name string, out *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+	inode, _ := n.LoopbackNode.Link(ctx, target, name, out)
+
+	fakeError := syscall.EXDEV
+
+	return inode, fakeError
+}
+
 func (n *rfsRoot) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
 	fh, flags, _ := n.LoopbackNode.Open(ctx, flags)
 

--- a/rfs/root_file.go
+++ b/rfs/root_file.go
@@ -1,0 +1,24 @@
+package rfs
+
+import (
+	"context"
+	"syscall"
+
+	"github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/rs/zerolog/log"
+)
+
+func NewRfsFile(fd int) fs.FileHandle {
+	log.Info().Int("fd: ", fd).Msg("From NewRfsFile: ")
+	return &rfsFile{fs.NewLoopbackFile(fd)}
+}
+
+type rfsFile struct {
+	fs.FileHandle
+}
+
+func (f *rfsFile) Read(ctx context.Context, buf []byte, off int64) (res fuse.ReadResult, errno syscall.Errno) {
+	log.Info().Msg("Not logging - as Adam asked ;)")
+	return res, 0
+}

--- a/rfs/root_file.go
+++ b/rfs/root_file.go
@@ -11,11 +11,25 @@ import (
 
 func NewRfsFile(fd int) fs.FileHandle {
 	log.Info().Int("fd: ", fd).Msg("From NewRfsFile: ")
-	return &rfsFile{fs.NewLoopbackFile(fd)}
+	return &rfsFile{fs.NewLoopbackFile(fd).(loopbackFile)}
+}
+
+type loopbackFile interface {
+	Release(ctx context.Context) syscall.Errno
+	Getattr(ctx context.Context, out *fuse.AttrOut) syscall.Errno
+	Write(ctx context.Context, data []byte, off int64) (written uint32, errno syscall.Errno)
+	Getlk(ctx context.Context, owner uint64, lk *fuse.FileLock, flags uint32, out *fuse.FileLock) syscall.Errno
+	Setlk(ctx context.Context, owner uint64, lk *fuse.FileLock, flags uint32) syscall.Errno
+	Setlkw(ctx context.Context, owner uint64, lk *fuse.FileLock, flags uint32) syscall.Errno
+	Lseek(ctx context.Context, off uint64, whence uint32) (uint64, syscall.Errno)
+	Flush(ctx context.Context) syscall.Errno
+	Fsync(ctx context.Context, flags uint32) syscall.Errno
+	Setattr(ctx context.Context, in *fuse.SetAttrIn, out *fuse.AttrOut) syscall.Errno
+	Allocate(ctx context.Context, off uint64, size uint64, mode uint32) syscall.Errno
 }
 
 type rfsFile struct {
-	fs.FileHandle
+	loopbackFile
 }
 
 func (f *rfsFile) Read(ctx context.Context, buf []byte, off int64) (res fuse.ReadResult, errno syscall.Errno) {


### PR DESCRIPTION
## Implementation description
**Implemented functions which overwrite LoopbackNode functions and return fake errors. List of implemented functions:**
- `Create`
- `Link`
- `Mkdir`
- `Rename`
- `Rmdir`
- `Setattr`
- `Symlink`
- `Unlink` 
- `CopyFileRange` as write (???) - need to check this one
- custom `Open`

## Some doubts 
**Some questions**
Background info: there is no func `Write` in `LoopbackNode`. Func `Open` calls `NewLoopbackFile`, which ask for file descriptor and then it writes straight to the descriptor, so we had to write custom `Open` func.
We have some problems with with [code](https://github.com/Zamerykanizowana/replicated-file-system/blob/stub-implementation/rfs/root_file.go). Why it doesn't call methods (`Read`, `Write` etc.) from promoted field? Can we use interface as promoted field? @nieomylnieja 