### PR TITLE
Fix file permission and file writing issues

### DIFF
--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -42,7 +42,10 @@ func (m *Mirror) Mirror(request *protobuf.Request) error {
 			m.path(request.Metadata.RelativePath),
 			os.FileMode(request.Metadata.Mode))
 	case protobuf.Request_WRITE:
-		f, err := os.OpenFile(m.path(request.Metadata.RelativePath), os.O_WRONLY, 0)
+		f, err := os.OpenFile(
+			m.path(request.Metadata.RelativePath),
+			os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+			0)
 		if err != nil {
 			return err
 		}

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -180,8 +180,6 @@ func (r *rfsRoot) Setattr(ctx context.Context, fh fs.FileHandle, in *fuse.SetAtt
 		// No name as we're operating on the existing node (can't go deeper).
 		p := r.physicalPath("")
 
-		log.Info().Uint32("mode", mode).Str("physical_path", p)
-
 		if err := syscall.Chmod(p, mode); err != nil {
 			return fs.ToErrno(err)
 		}

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -200,6 +200,10 @@ func (r *rfsRoot) CopyFileRange(ctx context.Context, fhIn fs.FileHandle,
 	return fflags, fakeError
 }
 
+func (r *rfsRoot) physicalPath() string {
+	return filepath.Join(r.RootData.Path, r.relativePath(""))
+}
+
 func (r *rfsRoot) relativePath(name string) string {
 	return filepath.Join(r.Path(r.Root()), name)
 }

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -67,7 +67,7 @@ func (r *rfsRoot) Create(ctx context.Context, name string, flags uint32, mode ui
 	}
 
 	st := syscall.Stat_t{}
-	if err := syscall.Fstat(fd, &st); err != nil {
+	if err = syscall.Fstat(fd, &st); err != nil {
 		syscall.Close(fd)
 		return nil, nil, 0, fs.ToErrno(err)
 	}

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -34,6 +34,7 @@ const PermissionDenied = syscall.EPERM
 
 func (r *rfsRoot) Create(ctx context.Context, name string, flags uint32, mode uint32,
 	out *fuse.EntryOut) (*fs.Inode, fs.FileHandle, uint32, syscall.Errno) {
+	log.Info().Uint32("mode", mode).Msg("creating a file")
 
 	req := &protobuf.Request{
 		Type: protobuf.Request_CREATE,

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -233,8 +233,9 @@ func (r *rfsRoot) consultMirror(req *protobuf.Request) (permitted bool) {
 
 // idFromStat is a rip-off from go-fuse's loopback.go.
 func (r *rfsRoot) idFromStat(st *syscall.Stat_t) fs.StableAttr {
+	dev := r.LoopbackNode.RootData.Dev
 	swapped := (uint64(st.Dev) << 32) | (uint64(st.Dev) >> 32)
-	swappedRootDev := (r.Dev << 32) | (r.Dev >> 32)
+	swappedRootDev := (dev << 32) | (dev >> 32)
 	return fs.StableAttr{
 		Mode: uint32(st.Mode),
 		Gen:  1,

--- a/rfs/root.go
+++ b/rfs/root.go
@@ -230,3 +230,14 @@ func (r *rfsRoot) consultMirror(req *protobuf.Request) (permitted bool) {
 	}
 	return
 }
+
+// idFromStat is a rip-off from go-fuse's loopback.go.
+func (r *rfsRoot) idFromStat(st *syscall.Stat_t) fs.StableAttr {
+	swapped := (uint64(st.Dev) << 32) | (uint64(st.Dev) >> 32)
+	swappedRootDev := (r.Dev << 32) | (r.Dev >> 32)
+	return fs.StableAttr{
+		Mode: uint32(st.Mode),
+		Gen:  1,
+		Ino:  (swapped ^ swappedRootDev) ^ st.Ino,
+	}
+}

--- a/rfs/root_file.go
+++ b/rfs/root_file.go
@@ -66,3 +66,12 @@ func (f *rfsFile) Write(ctx context.Context, data []byte, off int64) (written ui
 
 	return f.loopbackFile.Write(ctx, data, off)
 }
+
+func (f *rfsFile) Lseek(ctx context.Context, off uint64, whence uint32) (uint64, syscall.Errno) {
+	log.Info().
+		Str("path", f.path).
+		Uint64("offset", off).
+		Uint32("whence", whence).
+		Msg("running lseek")
+	return f.loopbackFile.Lseek(ctx, off, whence)
+}


### PR DESCRIPTION
This PR fixes the following bugs:
* Under certain circumstances, files would be created with blank permissions on remotes nodes. The fix was implemented in such a way that the `setattr` command will not send a message if there's nothing to do (i.e. the user did not request mode change; we don't support any other operations, they will be silently ignored).
* Writing to a file descriptor obtained using the `create` command would not propagate the changes. The fix for this was to re-implemented some logic from the underlying loopback file system so that our custom file descriptor handler with hooks is used (instead of the default loopback handler).
* Removing lines from files would not propagate. The fix for this was to hardcode certain flags in the `os.OpenFile` invocation in mirror. Note that if the originator opened a file with different flags (e.g. without `os.O_TRUNC`) these will **NOT** get propagated. Thus, what I implemented could be considered kind of a hacky fix. We operate statelessly but the notion of file descriptors itself implies state. What we really should do (in near future ;) ) is implemented the notion of intermediate transaction. They would work in such a way that one command would start such a transaction (marking it as intermediate), and another command (marked as a terminating command) would finish it. This way we could implement some crude notion of distributed file descriptors.

In any case, this fixes some of the most annoying issues. I tested it using `nano`, `vim` and good old `echo`.