### PR TITLE
Allow dirty connections to be recovered

### DIFF
--- a/p2p/connection/perspective.go
+++ b/p2p/connection/perspective.go
@@ -61,12 +61,17 @@ type (
 //   - 00000110 --> { Perspective: Server, Counter: 2 }
 //
 // IF
-// 		The counter from the received resolvent is equal to the counter value
-// 		we've sent ourselves.
+//
+//	The counter from the received resolvent is equal to the counter value
+//	we've sent ourselves.
+//
 // OR
-// 		The counters differed but the fallback returns true.
+//
+//	The counters differed but the fallback returns true.
+//
 // THEN
-// 		The connection is successfully resolved.
+//
+//	The connection is successfully resolved.
 //
 // In any other case an error describing the reason for failed resolution is returned.
 func (p *perspectiveResolver) Resolve(
@@ -150,7 +155,7 @@ func (p *perspectiveResolvent) Encode() (b []byte) {
 	// It's dodgy that we assume 4 bits will suffice here.
 	// In theory this counter can grow forever If we keep losing the connection with the peer
 	// in a dirty manner (when the peer doesn't close the connection on its side).
-	return []byte{byte(uint32(p.Perspective)<<4 | p.ctr)}
+	return []byte{byte(uint32(p.Perspective)<<6 | p.ctr)}
 }
 
 // Decode decodes the resolvent reading Perspective and counter from the first 4 bits.
@@ -160,8 +165,8 @@ func (p *perspectiveResolvent) Decode(b []byte) error {
 			" expected exactly 1 byte, got %d with %v content", len(b), b)
 	}
 	// Right bit shift to get the last 4 bits.
-	p.Perspective = Perspective(b[0] >> 4)
-	// Apply 00001111 bitmask to get the first 4 bits.
-	p.ctr = uint32(b[0] & 15)
+	p.Perspective = Perspective(b[0] >> 6)
+	// Apply 00111111 bitmask to get the first 4 bits.
+	p.ctr = uint32(b[0] & 63)
 	return nil
 }

--- a/p2p/connection/perspective.go
+++ b/p2p/connection/perspective.go
@@ -48,25 +48,26 @@ type (
 //   - Server, when we're the ones accepting the connection
 //   - Client, when we're dialing the other peer
 //
-// It achieves it's goal via a single round trip during which we're sending
+// It achieves its goal via a single round trip during which we're sending
 // and receiving a message called perspective resolvent.
 // Perspective resolvent contains the following details:
 //   - the perspective for our connection (are we the Client or the Server?)
 //   - counter, which helps us keep track of the order in which we're handling
-//     client/server connections. It can be either 1 or 2.
+//     client/server connections.
 //
 // The resolvent carries a single byte which holds on positions
 // 3,4 Perspective and 1,2 counter. Here are some examples:
 //   - 00001001 --> { Perspective: Client, Counter: 1 }
 //   - 00000110 --> { Perspective: Server, Counter: 2 }
 //
-// If the counter from the received resolvent is equal to the counter value
-// we've sent ourselves
+// IF
+// 		The counter from the received resolvent is equal to the counter value
+// 		we've sent ourselves.
 // OR
-// the counters differed but the fallback returns true
-// AND
-// the counter is equal to 1 (first connection takes priority),
-// the connection is successfully resolved.
+// 		The counters differed but the fallback returns true.
+// THEN
+// 		The connection is successfully resolved.
+//
 // In any other case an error describing the reason for failed resolution is returned.
 func (p *perspectiveResolver) Resolve(
 	ctx context.Context,
@@ -74,29 +75,24 @@ func (p *perspectiveResolver) Resolve(
 	conn quic.Connection,
 	fallback resolveFallback,
 ) error {
-	resolved, first, err := p.resolve(ctx, perspective, conn)
+	resolved, err := p.resolve(ctx, perspective, conn)
 	if err != nil {
 		return errors.Wrapf(err, "failed to resolve connection perspective for %s", perspective)
 	}
 	if !resolved && !fallback() {
 		return errors.Wrap(connErrNotResolved, "perspective was not resolved and fallback did not apply")
 	}
-	if !first {
-		return errors.Wrap(connErrNotResolved, "perspective was not the first one to have been resolved")
-	}
 	return nil
 }
 
 // resolve receives the peer's resolvent asynchronously and sends the host's resolvent.
-// It returns resolved == true If both counters were equal and
-// first == true If the counter is equal to 0.
+// It returns resolved == true If both counters were equal.
 func (p *perspectiveResolver) resolve(
 	ctx context.Context,
 	perspective Perspective,
 	conn quic.Connection,
-) (resolved, first bool, err error) {
+) (resolved bool, err error) {
 	ctr := p.counter.Add(1)
-	first = ctr == 1
 
 	rcv := make(chan message)
 	go func() {
@@ -136,6 +132,12 @@ func (p *perspectiveResolver) Reset() {
 	p.counter.Store(0)
 }
 
+// Counter returns the underlying counter value.
+// Bear in mind that after loading the value it might already change.
+func (p *perspectiveResolver) Counter() uint32 {
+	return p.counter.Load()
+}
+
 // perspectiveResolvent is the message sent during perspective resolving round trip.
 // It holds Perspective and counter.
 type perspectiveResolvent struct {
@@ -143,9 +145,12 @@ type perspectiveResolvent struct {
 	ctr uint32 // 1 or 2
 }
 
-// Encode places the Perspective at the 3rd and 4th and counter at the 1st and 2nd bit position.
+// Encode places the Perspective at the 4 last bits and counter at the 4 first bit positions.
 func (p *perspectiveResolvent) Encode() (b []byte) {
-	return []byte{byte(uint32(p.Perspective)<<2 | p.ctr)}
+	// It's dodgy that we assume 4 bits will suffice here.
+	// In theory this counter can grow forever If we keep losing the connection with the peer
+	// in a dirty manner (when the peer doesn't close the connection on its side).
+	return []byte{byte(uint32(p.Perspective)<<4 | p.ctr)}
 }
 
 // Decode decodes the resolvent reading Perspective and counter from the first 4 bits.
@@ -154,9 +159,9 @@ func (p *perspectiveResolvent) Decode(b []byte) error {
 		return errors.Errorf("invalid perspectiveResolvent received,"+
 			" expected exactly 1 byte, got %d with %v content", len(b), b)
 	}
-	// Right bit shift to get the 3rd and 4th bits.
-	p.Perspective = Perspective(b[0] >> 2)
-	// Apply 0000011 bitmask to get the 1st and 2nd bits.
-	p.ctr = uint32(b[0] & 3)
+	// Right bit shift to get the last 4 bits.
+	p.Perspective = Perspective(b[0] >> 4)
+	// Apply 00001111 bitmask to get the first 4 bits.
+	p.ctr = uint32(b[0] & 15)
 	return nil
 }

--- a/p2p/connection/perspective_test.go
+++ b/p2p/connection/perspective_test.go
@@ -36,6 +36,7 @@ func TestPerspectiveResolver_Resolve(t *testing.T) {
 				return nil
 			},
 		}
+		resolver.counter.Store(0)
 
 		err := resolver.Resolve(context.Background(), Server, nil, func() bool { return true })
 		require.NoError(t, err)
@@ -51,7 +52,7 @@ func TestPerspectiveResolver_Resolve(t *testing.T) {
 				return nil
 			},
 		}
-		resolver.counter.Store(1)
+		resolver.counter.Store(0)
 
 		err := resolver.Resolve(context.Background(), Server, nil, func() bool { return false })
 		require.Error(t, err)

--- a/p2p/connection/pool.go
+++ b/p2p/connection/pool.go
@@ -43,7 +43,7 @@ func NewPool(
 	tlsConf.NextProtos = []string{Protocol}
 	p.tlsConfig = tlsConf
 
-	quicConf := quicConfig(p.connectionEstablishingTimeout)
+	quicConf := quicConfig()
 	p.quicConf = quicConf
 
 	p.dialFunc = quic.DialAddrContext

--- a/p2p/connection/quic.go
+++ b/p2p/connection/quic.go
@@ -15,12 +15,13 @@ type quicDial = func(
 	config *quic.Config,
 ) (quic.Connection, error)
 
-func quicConfig(handshakeTimeout time.Duration) *quic.Config {
+func quicConfig() *quic.Config {
 	return &quic.Config{
 		Versions:                       []quic.VersionNumber{quic.Version2},
 		ConnectionIDLength:             12,
-		HandshakeIdleTimeout:           handshakeTimeout,
-		MaxIdleTimeout:                 1 * time.Minute,
+		HandshakeIdleTimeout:           5 * time.Second,
+		MaxIdleTimeout:                 12 * time.Second,
+		KeepAlivePeriod:                4 * time.Second,
 		InitialStreamReceiveWindow:     (1 << 10) * 512,       // 512 Kb
 		MaxStreamReceiveWindow:         (1 << 20) * 6,         // 6 Mb
 		InitialConnectionReceiveWindow: (1 << 10) * 512 * 1.5, // 768 Kb
@@ -28,7 +29,6 @@ func quicConfig(handshakeTimeout time.Duration) *quic.Config {
 		MaxIncomingStreams:             -1,                    // Doesn't allow bidirectional streams.
 		MaxIncomingUniStreams:          100,
 		StatelessResetKey:              nil,
-		KeepAlivePeriod:                15 * time.Second,
 		DisablePathMTUDiscovery:        false,
 		// We're communicating between peers only, which are built with a single version.
 		DisableVersionNegotiationPackets: true,


### PR DESCRIPTION
The issue was observed when we didn't gracefully shutdown the connection, I noticed it when running Debug mode in GoLand. We were left in a zombie state, holding onto the lost connection for as long as the keep alive packet was not sent. To fix it I:

- largely reduced the keep alive period
- removed the logic around checking if the connection was "first" in `perspectiveResolver`. It was the real bug here since we relied on counter check `ctr == 1` to determine if we're dealing with the first connection and the counter was only reset when we were closing the connection. Since most of the time we were already running the perspective resolve when finally closing the connection (after keep alive failed) we almost always were ending up with a dirty counter value... You can see the logs from before the change here:
![2022-09-08_09-54](https://user-images.githubusercontent.com/48822818/189183234-02ccceac-4be9-43e0-887a-0dda7ac14830.png)

Here's the demo of how it works now:

https://user-images.githubusercontent.com/48822818/189181917-19558923-73ea-44b1-9532-205e9d11feb3.mp4